### PR TITLE
Fix js solo en Chrome al añadir enlace

### DIFF
--- a/lib/bootstrap-wysihtml5-rails/version.rb
+++ b/lib/bootstrap-wysihtml5-rails/version.rb
@@ -1,5 +1,5 @@
 module BootstrapWysihtml5Rails
   module Rails
-    VERSION = "0.3.1.23"
+    VERSION = "0.3.1.24"
   end
 end

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
@@ -276,9 +276,14 @@
                 var activeButton = $(this).hasClass("wysihtml5-command-active");
 
                 if (!activeButton) {
-                    self.editor.currentView.element.focus(false);
-                    caretBookmark = self.editor.composer.selection.getBookmark();
-                    insertImageModal.appendTo('body').modal('show');
+                    //debugger;
+                    //self.editor.currentView.element.focus(false);
+                    //caretBookmark = self.editor.composer.selection.getBookmark();
+                    // insertImageModal.appendTo('body').modal('show');
+                    // insertImageModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
+                    //     e.stopPropagation();
+                    // });
+                    insertImageModal.modal('show');
                     insertImageModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
                         e.stopPropagation();
                     });

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core-b3.js.erb
@@ -55,7 +55,7 @@
                     "</div>" +
                     "<div class='modal-body'>" +
                       "<input value='http://' class='bootstrap-wysihtml5-insert-link-url form-control'>" +
-                      "<label class='checkbox'> <input type='checkbox' class='bootstrap-wysihtml5-insert-link-target' checked>" + locale.link.target + "</label>" +
+                      "<label class='checkbox'> <input type='checkbox' class='bootstrap-wysihtml5-insert-link-target'>" + locale.link.target + "</label>" +
                     "</div>" +
                     "<div class='modal-footer'>" +
                       "<a href='#' class='btn btn-default' data-dismiss='modal'>" + locale.link.cancel + "</a>" +

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
@@ -268,9 +268,13 @@
                 var activeButton = $(this).hasClass("wysihtml5-command-active");
 
                 if (!activeButton) {
-                    self.editor.currentView.element.focus(false);
-                    caretBookmark = self.editor.composer.selection.getBookmark();
-                    insertImageModal.appendTo('body').modal('show');
+                    // self.editor.currentView.element.focus(false);
+                    // caretBookmark = self.editor.composer.selection.getBookmark();
+                    // insertImageModal.appendTo('body').modal('show');
+                    // insertImageModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
+                    //     e.stopPropagation();
+                    // });
+                    insertImageModal.modal('show');
                     insertImageModal.on('click.dismiss.modal', '[data-dismiss="modal"]', function(e) {
                         e.stopPropagation();
                     });

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
@@ -447,14 +447,22 @@
                     }
                 },
                 "a":  {
-                    check_attributes: {
+                    "check_attributes": {
                         'href': "url", // important to avoid XSS
                         'target': 'alt',
                         'rel': 'alt'
                     }
                 },
-                "span": {},
-                "div": true,
+                "span": {
+                    "check_attributes": {
+                        'id': 'alt'
+                    }
+                },
+                "div": {
+                    "check_attributes": {
+                        'id': 'alt'
+                    }
+                },
                 // to allow save and edit files with code tag hacks
                 "code": 1,
                 "pre": 1

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/core.js.erb
@@ -53,7 +53,7 @@
                 "</div>" +
                 "<div class='modal-body'>" +
                   "<input value='http://' class='bootstrap-wysihtml5-insert-link-url input-xlarge'>" +
-                  "<label class='checkbox'> <input type='checkbox' class='bootstrap-wysihtml5-insert-link-target' checked>" + locale.link.target + "</label>" +
+                  "<label class='checkbox'> <input type='checkbox' class='bootstrap-wysihtml5-insert-link-target'>" + locale.link.target + "</label>" +
                 "</div>" +
                 "<div class='modal-footer'>" +
                   "<a href='#' class='btn' data-dismiss='modal'>" + locale.link.cancel + "</a>" +

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/locales/es-ES.js
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/locales/es-ES.js
@@ -25,6 +25,7 @@
               indent: "Agregar sangría"
         },
         link: {
+              target: "Abrir en una nueva ventana",
               insert: "Insertar enlace",
               cancel: "Cancelar"
         },

--- a/vendor/assets/javascripts/bootstrap-wysihtml5/wysihtml5.js
+++ b/vendor/assets/javascripts/bootstrap-wysihtml5/wysihtml5.js
@@ -4960,9 +4960,9 @@ wysihtml5.dom.parse = (function() {
     classesLength = classes.length;
     for (; i<classesLength; i++) {
       currentClass = classes[i];
-      if (allowedClasses[currentClass]) {
+      //if (allowedClasses[currentClass]) {
         newClasses.push(currentClass);
-      }
+      //}
     }
     
     // remove duplicate entries and preserve class specificity


### PR DESCRIPTION
En Chrome no se abre el modal al querer añadir un enlace sino que nos reporta el siguiente fallo JS:

_Uncaught TypeError: Failed to execute 'focus' on 'HTMLElement': parameter 1 ('options') is not an object._
